### PR TITLE
Cheddar mint

### DIFF
--- a/cheddar/src/lib.rs
+++ b/cheddar/src/lib.rs
@@ -79,23 +79,22 @@ impl Contract {
         return self.owner_id.clone();
     }
 
-    //minters can mint more
+    /// minters can mint more
     #[payable]
     pub fn mint(&mut self, account_id: &AccountId, amount: U128String) {
         assert_one_yocto();
+        env_log!("Minting {} CHEDDAR to {}", amount.0, account_id);
         self.assert_minter(env::predecessor_account_id());
         self.mint_into(account_id, amount.0);
     }
 
-    //minters can also burn. La main qui donne est au-dessus de la main qui reçoit
-    #[payable]
-    pub fn burn(&mut self, account_id: &AccountId, amount: U128String) {
+    /// burns `amount` from own supply of coins
+    pub fn self_burn(&mut self, amount: U128String) {
         assert_one_yocto();
-        self.assert_minter(env::predecessor_account_id());
-        self.internal_burn(account_id, amount.0);
+        self.internal_burn(&env::predecessor_account_id(), amount.0);
     }
 
-    //owner can add/remove minters
+    /// owner can add/remove minters
     #[payable]
     pub fn add_minter(&mut self, account_id: AccountId) {
         assert_one_yocto();

--- a/cheddar/src/util.rs
+++ b/cheddar/src/util.rs
@@ -10,6 +10,16 @@ construct_uint! {
 }
 
 /// returns amount * numerator/denominator
-pub fn proportional(amount: u128, numerator: u128, denominator: u128) -> u128 {
+pub fn fraction_of(amount: u128, numerator: u128, denominator: u128) -> u128 {
     return (U256::from(amount) * U256::from(numerator) / U256::from(denominator)).as_u128();
+}
+
+#[macro_export]
+macro_rules! env_log {
+    ($($arg:tt)*) => {{
+        let msg = format!($($arg)*);
+        // io::_print(msg);
+        println!("{}", msg);
+        env::log(msg.as_bytes())
+    }}
 }

--- a/cheddar/src/vesting.rs
+++ b/cheddar/src/vesting.rs
@@ -62,7 +62,7 @@ impl VestingRecord {
             // The total time is positive. Checked at the contract initialization.
             let total_time = self.end_timestamp - self.cliff_timestamp;
             // locked amount is linearly reduced until time_left = 0 (end_timestamp)
-            proportional(self.amount, time_left as u128, total_time as u128)
+            fraction_of(self.amount, time_left as u128, total_time as u128)
         };
     }
 }

--- a/p1-staking-pool-dyn/src/interfaces.rs
+++ b/p1-staking-pool-dyn/src/interfaces.rs
@@ -22,12 +22,13 @@ pub trait StakingPool {
 
 #[ext_contract(ext_self)]
 pub trait ExtStakingPool {
-    fn withdraw_callback(&mut self, sender_id: AccountId, amount: U128);
+    fn withdraw_callback(&mut self, sender_id: AccountId, amount: U128, close: bool);
 }
 
 #[ext_contract(ext_ft)]
 pub trait FungibleToken {
     fn ft_transfer(&mut self, receiver_id: AccountId, amount: U128, memo: Option<String>);
+    fn mint(&mut self, account_id: AccountId, amount: U128);
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
+ removed burn function - we should not allow minters to burn user coins
+ added `self_burn` function - anyone can self burn some amount of his tokens.
+ use `cheddar.mint` for transferring user rewards instead of cheddar "pre-allocation"
+ fixed a logic with closing account: in the `close` function we delete the user vault, but if minting / transfer fails, we don't recover it.