### PR TITLE
fix near withdraw

### DIFF
--- a/p1-staking-pool-dyn/src/interfaces.rs
+++ b/p1-staking-pool-dyn/src/interfaces.rs
@@ -22,7 +22,13 @@ pub trait StakingPool {
 
 #[ext_contract(ext_self)]
 pub trait ExtStakingPool {
-    fn mint_callback(&mut self, user: AccountId, amount: U128, close: bool);
+    fn mint_callback(
+        &mut self,
+        user: AccountId,
+        amount_near: U128,
+        amount_cheddar: U128,
+        close: bool,
+    );
 }
 
 #[ext_contract(ext_ft)]


### PR DESCRIPTION
+ I have renamed the  `mint_cheddar_promise_maybe_close_account` function (it's too long, but I didn't make it much shorter)
+ updated moved logs to places where we know that cheddar farming was successful
+ moved NEAR transfer after cheddar minting was successful
+ assure the state is correct and we don't do double spend with withdraw.