### PR TITLE
Then+finally pattern 

### DIFF
--- a/p1-staking-pool-dyn/src/constants.rs
+++ b/p1-staking-pool-dyn/src/constants.rs
@@ -4,7 +4,10 @@ use near_sdk::{Balance, Gas};
 // pub const GAS_FOR_FT_TRANSFER_CALL: Gas = 25_000_000_000_000 + GAS_FOR_RESOLVE_TRANSFER;
 
 /// Amount of gas for fungible token transfers.
-pub const GAS_FOR_FT_TRANSFER: Gas = 10_000_000_000_000;
+pub const TGAS: Gas = 1_000_000_000_000;
+pub const GAS_FOR_FT_TRANSFER: Gas = 10 * TGAS;
+pub const GAS_FOR_MINT_CALLBACK: Gas = 20 * TGAS;
+pub const GAS_FOR_MINT_CALLBACK_FINALLY: Gas = 8 * TGAS;
 
 pub const NO_DEPOSIT: Balance = 0;
 pub const ONE_YOCTO: Balance = 1;

--- a/p1-staking-pool-dyn/src/interfaces.rs
+++ b/p1-staking-pool-dyn/src/interfaces.rs
@@ -23,6 +23,7 @@ pub trait StakingPool {
 #[ext_contract(ext_self)]
 pub trait ExtStakingPool {
     fn mint_callback(&mut self, user: AccountId, amount: U128, close: bool);
+    fn mint_failed_callback(&mut self);
 }
 
 #[ext_contract(ext_ft)]

--- a/p1-staking-pool-dyn/src/interfaces.rs
+++ b/p1-staking-pool-dyn/src/interfaces.rs
@@ -21,9 +21,9 @@ pub trait StakingPool {
 }
 
 #[ext_contract(ext_self)]
-pub trait ExtStakingPool {
+pub trait ExtSelf {
     fn mint_callback(&mut self, user: AccountId, amount: U128, close: bool);
-    fn mint_failed_callback(&mut self);
+    fn mint_callback_finally(&mut self, user: AccountId);
 }
 
 #[ext_contract(ext_ft)]

--- a/p1-staking-pool-dyn/src/lib.rs
+++ b/p1-staking-pool-dyn/src/lib.rs
@@ -7,7 +7,7 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LookupMap;
 use near_sdk::json_types::{ValidAccountId, U128};
 use near_sdk::{
-    assert_one_yocto, env, near_bindgen, AccountId, PanicOnDefault, Promise, PromiseResult, PromiseOrValue
+    assert_one_yocto, env, near_bindgen, AccountId, PanicOnDefault, Promise, PromiseResult,
 };
 
 pub mod constants;
@@ -192,20 +192,24 @@ impl Contract {
             to_transfer
         );
 
-        // since .transfer almost never fails, we better discount the unstaked here
-        // and update the vault to avoid allowing double-unstake if any other promise fails.
+        // since NEAR .transfer never fails, we better discount the unstaked here,
+        // update the vault to avoid allowing double-unstake if any other promise fails,
         // also zero the rewards to block double-withdraw-cheddar
         vault.staked = 0;
         vault.rewards = 0;
         self.vaults.insert(&aid.clone(), &vault);
         self.total_stake -= to_transfer;
 
-        // transfer back all user's NEAR
-        // we assume NEAR transfer can't fail
-        // then mint cheddar rewards for the user & close the account
-        Promise::new(aid.clone())
-            .transfer(to_transfer)
-            .then(self.mint_cheddar_promise_maybe_close_account(&aid, rewards_str, true))
+        // 1st promise is to transfer back all their NEAR, we assume near transfer does not fail
+        Promise::new(aid.clone()).transfer(to_transfer);
+        // note: returning an "and/joint" promises is forbidden now
+        // and joining the 2 promises with "then" causes the "transfer"
+        // to become the main promise for the callback,
+        // so the success/failure of the mint-call can not be evaluated.
+        // Creating 2 promises (batch) works correctly
+
+        // 2nd promise is to mint cheddar rewards for the user & close the account
+        return self.mint_cheddar_promise_maybe_close_account(&aid, rewards_str, true);
     }
 
     /// Withdraws all farmed CHEDDAR to the user. It doesn't close the account.
@@ -217,8 +221,10 @@ impl Contract {
         let (aid, mut vault) = self.get_vault();
         self.ping(&mut vault);
         let rewards = vault.rewards;
+        // zero the rewards to block double-withdraw-cheddar
+        vault.rewards = 0;
+        self.vaults.insert(&aid.clone(), &vault);
         return self.mint_cheddar_promise_maybe_close_account(&aid, rewards.into(), false);
-        //note: vault.rewards will be set to zero if the cheddar transfer to the user is successful
     }
 
     // ******************* //
@@ -256,21 +262,23 @@ impl Contract {
             close,
             &env::current_account_id(),
             NO_DEPOSIT,
-            2 * GAS_FOR_FT_TRANSFER,
+            GAS_FOR_MINT_CALLBACK,
+        ))
+        .then(ext_self::mint_callback_finally(
+            a.clone(),
+            &env::current_account_id(),
+            NO_DEPOSIT,
+            GAS_FOR_MINT_CALLBACK_FINALLY,
         ))
     }
 
     #[private]
-    pub fn mint_callback(
-        &mut self,
-        user: AccountId,
-        amount: U128,
-        close: bool,
-    ) -> PromiseOrValue<U128> {
+    pub fn mint_callback(&mut self, user: AccountId, amount: U128, close: bool) {
+        env_log!(
+            "mint_callback, env::promise_results_count()={}",
+            env::promise_results_count()
+        );
         // after the async call to mint rewards for the user
-        
-        env_log!("env::promise_results_count()={}",env::promise_results_count());
-
         assert_eq!(
             env::promise_results_count(),
             1,
@@ -281,12 +289,12 @@ impl Contract {
             PromiseResult::NotReady => unreachable!(),
 
             PromiseResult::Successful(_) => {
+                env_log!("cheddar rewards withdrew {}",amount.0);
                 self.total_rewards += amount.0;
                 if close {
                     self.vaults.remove(&user);
                     env::log(b"account closed");
                 }
-                return PromiseOrValue::Value(amount);
             }
 
             PromiseResult::Failed => {
@@ -294,21 +302,19 @@ impl Contract {
                 let mut vault = self.vaults.get(&user).expect(ERR10_NO_ACCOUNT);
                 vault.rewards = amount.0;
                 self.vaults.insert(&user, &vault);
-                // causing the panic! in a promise lets us restore vault.rewards
-                PromiseOrValue::Promise(ext_self::mint_failed_callback(
-                        &env::current_account_id(),
-                        NO_DEPOSIT,
-                        GAS_FOR_FT_TRANSFER,
-                    )
-                )
             }
         }
     }
 
     #[private]
-    pub fn mint_failed_callback(&mut self) {
-        // just to inform the user that the mint/withdraw failed
-        panic!("{}", "cheddar transfer failed");
+    pub fn mint_callback_finally(&mut self, user: &AccountId) {
+        //Check if rewards were withdrew
+        if let Some(vault) = self.vaults.get(&user) {
+            if vault.rewards != 0 {
+                //if there are cheddar rewards, means the cheddar transfer failed
+                panic!("{}", "cheddar transfer failed");
+            }
+        }
     }
 
     fn assert_owner_calling(&self) {

--- a/p1-staking-pool-dyn/src/lib.rs
+++ b/p1-staking-pool-dyn/src/lib.rs
@@ -289,7 +289,7 @@ impl Contract {
             PromiseResult::NotReady => unreachable!(),
 
             PromiseResult::Successful(_) => {
-                env_log!("cheddar rewards withdrew {}",amount.0);
+                env_log!("cheddar rewards withdrew {}", amount.0);
                 self.total_rewards += amount.0;
                 if close {
                     self.vaults.remove(&user);


### PR DESCRIPTION
Implement Then+finally pattern 
Implement Robert's fix to avoid double withdraw, now vault.rewards is zeroed on close() & also on withdraw_crop(). *if* the cheddar mint fails, then the rewards are restored
