### PR TITLE
Eugene audit 2021 06 25

### DIFF
--- a/cheddar/src/lib.rs
+++ b/cheddar/src/lib.rs
@@ -1,3 +1,7 @@
+// [AUDIT] NOTE: Storage cost is still an issue. An account with 125 bytes costs 0.00125 `NEAR`.
+// I think the transaction to create it is cheaper than that, so it's possible to lock the contract
+// due to the storage limitation.
+
 /// Cheddar Token
 ///
 /// Functionality:
@@ -149,6 +153,8 @@ impl Contract {
 
     /// Get the amount of tokens that are locked in this account due to lockup or vesting.
     pub fn get_locked_amount(&self) -> U128String {
+        // [AUDIT] NOTE: View methods don't have `predecessor_account_id`.
+        //    Just add an argument for the account ID.
         match self.vested.get(&env::predecessor_account_id()) {
             Some(vesting) => vesting.compute_amount_locked().into(),
             None => 0.into(),

--- a/p1-staking-pool-dyn/Cargo.toml
+++ b/p1-staking-pool-dyn/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+# AUDIT: serde and serde_json don't need to be imported, since you can use `near_sdk::serde` and `near_sdk::serde_json`
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"
 uint = { version = "0.9.0", default-features = false }

--- a/p1-staking-pool-dyn/src/constants.rs
+++ b/p1-staking-pool-dyn/src/constants.rs
@@ -15,7 +15,8 @@ pub const NANOSECONDS: u64 = 1_000_000_000;
 pub const ROUND: u64 = NANOSECONDS; // 1 sec
 pub const ROUNDS_PER_MINUTE: u64 = 60; // 1 minute of rounds
 
-// 1/10_000 of a NEAR
+// AUDIT: fixed comment
+// 1/1_000 of a NEAR
 const MILLI_NEAR: Balance = 1000_000000_000000_000000;
 pub const MIN_STAKE: Balance = MILLI_NEAR * 10; // 0.01 NEAR
 pub const E24: Balance = MILLI_NEAR * 1_000;

--- a/p1-staking-pool-dyn/src/vault.rs
+++ b/p1-staking-pool-dyn/src/vault.rs
@@ -45,6 +45,8 @@ impl Contract {
         }
         let delta = now - v.previous;
         if delta > 0 {
+            // AUDIT: Why multiple as U256, if there are no division by U256?
+            //     Maybe `big(v.staked / E24)` should be `big(v.staked) / big(E24)`?
             let farmed = (U256::from(delta) * big(self.rate) * big(v.staked / E24)).as_u128();
             v.rewards += farmed;
             println!(


### PR DESCRIPTION
A good principle for working with async operations are atomic increments instead of atomic replacements.
When closing/withdrawing cheddar the contract has to do the following:

- Transfer staked balance.
- Transfer rewards (cheddar).

We assume the staked balance can't fail (which is mostly true), so we assume it always succeed as long as we are able to save the state. Let's keep it this way. The only remaining issue is to transfer rewards which may fail for some reason (e.g. if the cheddar would implement storage management, then the transfer may fail because the receiver is not registered for storage). In case of reward transfer failure we have to handle the rollback.

The problem with current implementation is that the rollback is atomic replacement, instead of atomic increment. If the affected vault has changed while the transfer was in progress the atomic replacement will overwrite the value, instead of updating it.

There are 2 suggestions:
1. Introduce methods `save_vault` and `get_vault_or_default`.
    - `save_vault(account_id, vault)` should check if the vault is empty or not. In case the vault is empty, it should remove it, if it's not empty, it should save it using insert.
    - `get_vault_or_default(account_id)` should read a vault for a given account or create an empty one. It should also ping this vault (for existing one).
    - Now you don't have to manually decide whether to remove or insert a vault, and can't accidentally delete a non empty vault.
2. Cheddar transfer with 1 callback.
  - You don't need 2 callbacks just to communicate the result of the transfer. You may use the returned value from the callback to do this. E.g. `mint_callback(...) -> bool`. `true` can be success, `false` is a failure.
  - You don't need to pass `close: bool` since you use `save_vault` in the both `withdraw_crop` and `close`. So the vault will be autoclosed.
  - You only need to handle if the transfer has failed and revert the reward, e.g. using the following code:
```rust
    #[private]
    pub fn mint_callback(&mut self, user: AccountId, amount: U128) -> bool {
        let transfer_success = near_sdk::is_promise_success();
        if transfer_success {
            env_log!("cheddar rewards withdrew {}", amount.0);
            self.total_rewards += amount.0;
        } else {
            env_log!("FAILED to withdrew {}", amount.0);
            let mut vault = self.get_vault_or_default(&user);
            vault.rewards += amount.0;
            self.save_vault(&user, &vault);
        }
        transfer_success
    }
```  