### PR TITLE
Cheddar token review + user feedback

### DIFF
--- a/cheddar/src/internal.rs
+++ b/cheddar/src/internal.rs
@@ -3,20 +3,6 @@ use near_sdk::{AccountId, Balance, PromiseResult};
 
 use crate::*;
 
-pub fn default_ft_metadata() -> FungibleTokenMetadata {
-    FungibleTokenMetadata {
-        spec: FT_METADATA_SPEC.to_string(),
-        name: "Chedder".to_string(),
-        symbol: "CHDR".to_string(),
-        icon: Some(String::from(
-            r###"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56"><style>.a{fill:#F4C647;}.b{fill:#EEAF4B;}</style><path d="M45 19.5v5.5l4.8 0.6 0-11.4c-0.1-3.2-11.2-6.7-24.9-6.7 -13.7 0-24.8 3.6-24.9 6.7L0 32.5c0 3.2 10.7 7.1 24.5 7.1 0.2 0 0.3 0 0.5 0V21.5l-4.7-7.2L45 19.5z" class="a"/><path d="M25 31.5v-10l-4.7-7.2L45 19.5v5.5l-14-1.5v10C31 33.5 25 31.5 25 31.5z" fill="#F9E295"/><path d="M24.9 7.5C11.1 7.5 0 11.1 0 14.3s10.7 7.2 24.5 7.2c0.2 0 0.3 0 0.5 0l-4.7-7.2 25 5.2c2.8-0.9 4.4-4 4.4-5.2C49.8 11.1 38.6 7.5 24.9 7.5z" class="b"/><path d="M36 29v19.6c8.3 0 15.6-1 20-2.5V26.5L31 23.2 36 29z" class="a"/><path d="M31 23.2l5 5.8c8.2 0 15.6-1 19.9-2.5L31 23.2z" class="b"/><polygon points="36 29 36 48.5 31 42.5 31 23.2 " fill="#FCDF76"/></svg>"###,
-        )),
-        reference: None, // TODO
-        reference_hash: None,
-        decimals: 24,
-    }
-}
-
 impl Contract {
     pub fn assert_owner_calling(&self) {
         assert!(
@@ -29,16 +15,14 @@ impl Contract {
         assert!(self.minters.contains(&account_id), "not a minter");
     }
 
-    //get stored metadata or default
+    /// get stored metadata or default
+    #[inline]
     pub fn internal_get_ft_metadata(&self) -> FungibleTokenMetadata {
-        self.metadata.get().unwrap_or(default_ft_metadata())
+        self.metadata.get().unwrap()
     }
 
     pub fn internal_unwrap_balance_of(&self, account_id: &AccountId) -> Balance {
-        match self.accounts.get(&account_id) {
-            Some(balance) => balance,
-            None => 0,
-        }
+        self.accounts.get(&account_id).unwrap_or(0)
     }
 
     pub fn mint_into(&mut self, account_id: &AccountId, amount: Balance) {
@@ -113,19 +97,20 @@ impl Contract {
         }
     }
 
-    // TODO rename
+    /// Relper function which computes the amount refunded from the transfer_call and adjust
+    /// sender and receiver balances.
+    /// Returns: `(amount transferred, amount_unused)`
     pub fn int_ft_resolve_transfer(
         &mut self,
         sender_id: &AccountId,
         receiver_id: ValidAccountId,
         amount: U128,
     ) -> (u128, u128) {
-        let sender_id: AccountId = sender_id.into();
         let receiver_id: AccountId = receiver_id.into();
         let amount: Balance = amount.into();
 
         // Get the unused amount from the `ft_on_transfer` call result.
-        let unused_amount = match env::promise_result(0) {
+        let mut unused_amount = match env::promise_result(0) {
             PromiseResult::NotReady => unreachable!(),
             PromiseResult::Successful(value) => {
                 if let Ok(unused_amount) = near_sdk::serde_json::from_slice::<U128>(&value) {
@@ -139,27 +124,36 @@ impl Contract {
 
         if unused_amount > 0 {
             let receiver_balance = self.accounts.get(&receiver_id).unwrap_or(0);
+            // receiver has positive balance, so we can refund.
             if receiver_balance > 0 {
-                let refund_amount = std::cmp::min(receiver_balance, unused_amount);
+                // adjust the refund amount to the receiver balance
+                unused_amount = std::cmp::min(receiver_balance, unused_amount);
                 self.accounts
-                    .insert(&receiver_id, &(receiver_balance - refund_amount));
+                    .insert(&receiver_id, &(receiver_balance - unused_amount));
 
-                if let Some(sender_balance) = self.accounts.get(&sender_id) {
+                // now we will try to update sender balance
+                if let Some(sender_balance) = self.accounts.get(sender_id) {
                     self.accounts
-                        .insert(&sender_id, &(sender_balance + refund_amount));
+                        .insert(sender_id, &(sender_balance + unused_amount));
                     log!(
                         "Refund {} from {} to {}",
-                        refund_amount,
+                        unused_amount,
                         receiver_id,
                         sender_id
                     );
-                    return (amount - refund_amount, 0);
+                    return (amount - unused_amount, 0);
                 } else {
                     // Sender's account was deleted, so we need to burn tokens.
-                    self.total_supply -= refund_amount;
-                    log!("The account of the sender was deleted");
-                    return (amount, refund_amount);
+                    self.total_supply -= unused_amount;
+                    log!(
+                        "The sender account is deleted, can't make a refund. Burning {} from ft_transfer_call",
+                        unused_amount
+                    );
+                    return (amount - unused_amount, unused_amount);
                 }
+            } else {
+                log!("Reciever {} didn't use all tokens, but it's balance is 0 so can't refund {} tokens to the sender",
+                     &receiver_id, unused_amount);
             }
         }
         (amount, 0)

--- a/cheddar/src/lib.rs
+++ b/cheddar/src/lib.rs
@@ -13,16 +13,13 @@
 /// an external contract, a farm for example, to be able to mint tokens
 /// - Ultra-Lazy ft-metadata: ft-metadata is not stored unless changed
 ///
-use near_sdk::collections::LookupMap;
-
 use near_contract_standards::fungible_token::{
     core::FungibleTokenCore,
     metadata::{FungibleTokenMetadata, FungibleTokenMetadataProvider, FT_METADATA_SPEC},
     resolver::FungibleTokenResolver,
 };
-
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::LazyOption;
+use near_sdk::collections::{LazyOption, LookupMap};
 use near_sdk::json_types::{ValidAccountId, U128};
 use near_sdk::{
     assert_one_yocto, env, ext_contract, log, near_bindgen, AccountId, Balance, Gas,
@@ -49,28 +46,33 @@ pub struct Contract {
     metadata: LazyOption<FungibleTokenMetadata>,
 
     pub accounts: LookupMap<AccountId, Balance>,
-
     pub owner_id: AccountId,
-
     pub minters: Vec<AccountId>,
-
     pub total_supply: Balance,
-
     pub vested: LookupMap<AccountId, VestingRecord>,
 }
 
 #[near_bindgen]
 impl Contract {
     /// Initializes the contract with the given total supply owned by the given `owner_id`.
-
     #[init]
     pub fn new(owner_id: AccountId) -> Self {
-        //validate default metadata
-        internal::default_ft_metadata().assert_valid();
+        let m = FungibleTokenMetadata {
+            spec: FT_METADATA_SPEC.to_string(),
+            name: "Cheddar".to_string(),
+            symbol: "Cheddar".to_string(),
+            icon: Some(String::from(
+                r###"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56"><style>.a{fill:#F4C647;}.b{fill:#EEAF4B;}</style><path d="M45 19.5v5.5l4.8 0.6 0-11.4c-0.1-3.2-11.2-6.7-24.9-6.7 -13.7 0-24.8 3.6-24.9 6.7L0 32.5c0 3.2 10.7 7.1 24.5 7.1 0.2 0 0.3 0 0.5 0V21.5l-4.7-7.2L45 19.5z" class="a"/><path d="M25 31.5v-10l-4.7-7.2L45 19.5v5.5l-14-1.5v10C31 33.5 25 31.5 25 31.5z" fill="#F9E295"/><path d="M24.9 7.5C11.1 7.5 0 11.1 0 14.3s10.7 7.2 24.5 7.2c0.2 0 0.3 0 0.5 0l-4.7-7.2 25 5.2c2.8-0.9 4.4-4 4.4-5.2C49.8 11.1 38.6 7.5 24.9 7.5z" class="b"/><path d="M36 29v19.6c8.3 0 15.6-1 20-2.5V26.5L31 23.2 36 29z" class="a"/><path d="M31 23.2l5 5.8c8.2 0 15.6-1 19.9-2.5L31 23.2z" class="b"/><polygon points="36 29 36 48.5 31 42.5 31 23.2 " fill="#FCDF76"/></svg>"###,
+            )),
+            reference: None,
+            reference_hash: None,
+            decimals: 24,
+        };
+        m.assert_valid();
 
         Self {
             owner_id: owner_id.clone(),
-            metadata: LazyOption::new(b"m".to_vec(), None),
+            metadata: LazyOption::new(b"m".to_vec(), Some(&m)),
             accounts: LookupMap::new(b"a".to_vec()),
             minters: vec![owner_id],
             total_supply: 0,
@@ -87,7 +89,7 @@ impl Contract {
     #[payable]
     pub fn mint(&mut self, account_id: &AccountId, amount: U128String) {
         assert_one_yocto();
-        env_log!("Minting {} CHEDDAR to {}", amount.0, account_id);
+        log!("Minting {} CHEDDAR to {}", amount.0, account_id);
         self.assert_minter(env::predecessor_account_id());
         self.mint_into(account_id, amount.0);
     }

--- a/cheddar/src/lib.rs
+++ b/cheddar/src/lib.rs
@@ -275,7 +275,7 @@ impl FungibleTokenResolver for Contract {
     ) -> U128 {
         let sender_id: AccountId = sender_id.into();
         let (used_amount, burned_amount) =
-            self.int_ft_resolve_transfer(&sender_id, receiver_id, amount);
+            self.ft_resolve_transfer_adjust(&sender_id, receiver_id, amount);
         if burned_amount > 0 {
             log!("{} tokens burned", burned_amount);
         }

--- a/cheddar/src/util.rs
+++ b/cheddar/src/util.rs
@@ -13,13 +13,3 @@ construct_uint! {
 pub fn fraction_of(amount: u128, numerator: u128, denominator: u128) -> u128 {
     return (U256::from(amount) * U256::from(numerator) / U256::from(denominator)).as_u128();
 }
-
-#[macro_export]
-macro_rules! env_log {
-    ($($arg:tt)*) => {{
-        let msg = format!($($arg)*);
-        // io::_print(msg);
-        println!("{}", msg);
-        env::log(msg.as_bytes())
-    }}
-}

--- a/p1-staking-pool-dyn/src/lib.rs
+++ b/p1-staking-pool-dyn/src/lib.rs
@@ -96,14 +96,21 @@ impl Contract {
         }
     }
 
-    /// Returns amount of staked NEAR, farmed CHEDDAR and the current round.
-    pub fn status(&self, account_id: AccountId) -> (U128, U128, u64) {
+    /// Returns amount of total staked NEAR, user staked NEAR, farmed CHEDDAR
+    /// and the current round.
+    pub fn status(&self, account_id: AccountId) -> (U128, U128, U128, u64) {
         let mut v = self.get_vault_or_default(&account_id);
         return (
+            self.total_stake.into(),
             v.staked.into(),
             self.ping(&mut v).into(),
             round_to_unix(current_round()),
         );
+    }
+
+    /// Return amount of currently staked NEAR (in total).
+    pub fn total_staked(&self) -> U128 {
+        self.total_stake.into()
     }
 
     // ******************* //

--- a/p1-staking-pool-dyn/src/lib.rs
+++ b/p1-staking-pool-dyn/src/lib.rs
@@ -7,7 +7,8 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LookupMap;
 use near_sdk::json_types::{ValidAccountId, U128};
 use near_sdk::{
-    assert_one_yocto, env, near_bindgen, AccountId, PanicOnDefault, Promise, PromiseResult,PromiseOrValue
+    assert_one_yocto, env, log, near_bindgen, AccountId, PanicOnDefault, Promise, PromiseOrValue,
+    PromiseResult,
 };
 
 pub mod constants;
@@ -154,7 +155,7 @@ impl Contract {
         self.total_stake -= amount;
         self.save_vault(&aid, &vault);
         Promise::new(aid).transfer(amount);
-        return PromiseOrValue::Value(amount.into())
+        return PromiseOrValue::Value(amount.into());
     }
 
     /// Unstakes everything and close the account. Sends all farmed CHEDDAR using a ft_transfer
@@ -168,7 +169,7 @@ impl Contract {
         let aid = env::predecessor_account_id();
         let mut vault = self.get_vault_or_default(&aid);
         self.ping(&mut vault);
-        env_log!(
+        log!(
             "Closing {} account, farmed CHEDDAR: {}",
             &aid,
             vault.rewards
@@ -277,7 +278,7 @@ impl Contract {
             PromiseResult::NotReady => unreachable!(),
 
             PromiseResult::Successful(_) => {
-                env_log!("cheddar rewards withdrew {}", amount.0);
+                log!("cheddar rewards withdrew {}", amount.0);
                 self.total_rewards += amount.0;
             }
 
@@ -314,16 +315,6 @@ impl Contract {
     fn assert_open(&self) {
         assert!(self.is_active, "Farming is not open");
     }
-}
-
-#[macro_export]
-macro_rules! env_log {
-    ($($arg:tt)*) => {{
-        let msg = format!($($arg)*);
-        // io::_print(msg);
-        println!("{}", msg);
-        env::log(msg.as_bytes())
-    }}
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/p1-staking-pool-dyn/src/lib.rs
+++ b/p1-staking-pool-dyn/src/lib.rs
@@ -96,12 +96,11 @@ impl Contract {
         }
     }
 
-    /// Returns amount of total staked NEAR, user staked NEAR, farmed CHEDDAR
+    /// Returns amount of user staked NEAR, farmed CHEDDAR
     /// and the current round.
-    pub fn status(&self, account_id: AccountId) -> (U128, U128, U128, u64) {
+    pub fn status(&self, account_id: AccountId) -> (U128, U128, u64) {
         let mut v = self.get_vault_or_default(&account_id);
         return (
-            self.total_stake.into(),
             v.staked.into(),
             self.ping(&mut v).into(),
             round_to_unix(current_round()),

--- a/p1-staking-pool-fixed/src/lib.rs
+++ b/p1-staking-pool-fixed/src/lib.rs
@@ -7,7 +7,7 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LookupMap;
 use near_sdk::json_types::{ValidAccountId, U128};
 use near_sdk::{
-    assert_one_yocto, env, near_bindgen, AccountId, PanicOnDefault, Promise, PromiseResult,
+    assert_one_yocto, env, log, near_bindgen, AccountId, PanicOnDefault, Promise, PromiseResult,
 };
 
 pub mod constants;
@@ -171,7 +171,7 @@ impl Contract {
         assert_one_yocto();
         let (aid, mut vault) = self.get_vault();
         self.ping(&mut vault);
-        env_log!(
+        log!(
             "Closing {} account, farmed CHEDDAR: {}",
             &aid,
             vault.rewards
@@ -244,7 +244,7 @@ impl Contract {
                 let mut v = self.vaults.get(&sender_id).expect(ERR10_NO_ACCOUNT);
                 v.rewards += amount.0;
                 self.vaults.insert(&sender_id, &v);
-                env_log!("cheddar transfer failed")
+                log!("cheddar transfer failed")
             }
         };
     }
@@ -259,16 +259,6 @@ impl Contract {
     fn assert_open(&self) {
         assert!(self.is_active, "Farming is not open");
     }
-}
-
-#[macro_export]
-macro_rules! env_log {
-    ($($arg:tt)*) => {{
-        let msg = format!($($arg)*);
-        // io::_print(msg);
-        println!("{}", msg);
-        env::log(msg.as_bytes())
-    }}
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]


### PR DESCRIPTION
+ Fixed function scope modifiers. Many internal functions were exposed as public, but they should be private.
+ removed `default_ft_metadata` and moved the default metadata as an initial metadata value in the constructor.
+ added logs and comments to `int_ft_resolve_transfer`  and renamed it to `ft_resolve_transfer_adjust`
+ removed `env_log` macro and use `log` macro from the SDK instead. 
+ added `total_staked` view method to `p1` staking pool

BREAKING:
+ changed return values of `p1.status`  function - added `total_stake` as a return value.