### PR TITLE
fix minter authorization and other review udpates

### DIFF
--- a/cheddar/src/internal.rs
+++ b/cheddar/src/internal.rs
@@ -4,7 +4,7 @@ use near_sdk::{AccountId, Balance, PromiseResult};
 use crate::*;
 
 impl Contract {
-    pub(crate) fn assert_owner_calling(&self) {
+    pub(crate) fn assert_owner(&self) {
         assert!(
             env::predecessor_account_id() == self.owner_id,
             "can only be called by the owner"

--- a/cheddar/src/internal.rs
+++ b/cheddar/src/internal.rs
@@ -39,18 +39,18 @@ impl Contract {
     }
 
     #[inline]
-    pub(crate) fn internal_unwrap_balance_of(&self, account_id: &AccountId) -> Balance {
+    pub(crate) fn unwrap_balance_of(&self, account_id: &AccountId) -> Balance {
         self.accounts.get(&account_id).unwrap_or(0)
     }
 
     pub(crate) fn mint_into(&mut self, account_id: &AccountId, amount: Balance) {
-        let balance = self.internal_unwrap_balance_of(account_id);
+        let balance = self.unwrap_balance_of(account_id);
         self.internal_update_account(&account_id, balance + amount);
         self.total_supply += amount;
     }
 
     pub(crate) fn internal_burn(&mut self, account_id: &AccountId, amount: u128) {
-        let balance = self.internal_unwrap_balance_of(account_id);
+        let balance = self.unwrap_balance_of(account_id);
         assert!(balance >= amount);
         self.internal_update_account(&account_id, balance - amount);
         assert!(self.total_supply >= amount);
@@ -71,7 +71,7 @@ impl Contract {
         assert!(amount > 0, "The amount should be a positive number");
 
         // remove from sender
-        let sender_balance = self.internal_unwrap_balance_of(sender_id);
+        let sender_balance = self.unwrap_balance_of(sender_id);
         assert!(
             amount <= sender_balance,
             "The account doesn't have enough balance {}",
@@ -96,7 +96,7 @@ impl Contract {
         }
 
         // add to receiver
-        let receiver_balance = self.internal_unwrap_balance_of(receiver_id);
+        let receiver_balance = self.unwrap_balance_of(receiver_id);
         self.internal_update_account(&receiver_id, receiver_balance + amount);
 
         log!("Transfer {} from {} to {}", amount, sender_id, receiver_id);

--- a/cheddar/src/lib.rs
+++ b/cheddar/src/lib.rs
@@ -26,7 +26,8 @@ use near_sdk::{
     PanicOnDefault, PromiseOrValue,
 };
 
-//-- Sputnik DAO remote upgrade requires BLOCKCHAIN_INTERFACE low-level access
+// Remote upgrade (when using function call to do self upgrade) requires
+// BLOCKCHAIN_INTERFACE low-level access
 #[cfg(target_arch = "wasm32")]
 use near_sdk::env::BLOCKCHAIN_INTERFACE;
 
@@ -39,9 +40,9 @@ near_sdk::setup_alloc!();
 
 mod empty_nep_145;
 mod internal;
+mod migrations;
 mod util;
 mod vesting;
-mod migrations;
 
 use util::*;
 use vesting::{VestingRecord, VestingRecordJSON};
@@ -81,9 +82,10 @@ impl Contract {
         return self.owner_id.clone();
     }
 
-    /// minters can mint more
+    /// Mints new tokens to the `account_id`.
+    /// Panics if the function is calle by a not registered minter.
     #[payable]
-    pub fn mint(&mut self, account_id: &AccountId, amount: U128String) {
+    pub fn ft_mint(&mut self, account_id: &AccountId, amount: U128String) {
         assert_one_yocto();
         log!("Minting {} CHEDDAR to {}", amount.0, account_id);
         self.assert_minter(env::predecessor_account_id());
@@ -168,7 +170,7 @@ impl Contract {
         }
     }
 
-    //minters can mint with vesting/locked periods
+    /// minters can mint with vesting/locked periods
     #[payable]
     pub fn mint_vested(
         &mut self,
@@ -177,7 +179,7 @@ impl Contract {
         cliff_timestamp: U64String,
         end_timestamp: U64String,
     ) {
-        self.mint(account_id, amount);
+        self.ft_mint(account_id, amount);
         let record =
             VestingRecord::new(amount.into(), cliff_timestamp.into(), end_timestamp.into());
         match self.vested.insert(&account_id, &record) {
@@ -187,11 +189,12 @@ impl Contract {
     }
 
     #[payable]
-    /// terminate vesting before the cliff
-    /// burn the tokens
-    pub fn terminate_vesting(&mut self, account_id: &AccountId) {
+    /// Cancels token allocation in a vesting account. All not vested tokens
+    /// will be burned.
+    /// Only owner can call this function.
+    pub fn cancel_vesting(&mut self, account_id: &AccountId) {
         assert_one_yocto();
-        self.assert_minter(env::predecessor_account_id());
+        self.assert_owner_calling();
         match self.vested.get(&account_id) {
             Some(vesting) => {
                 if vesting.compute_amount_locked() == 0 {
@@ -203,7 +206,6 @@ impl Contract {
             None => panic!("account not vested"),
         }
     }
-
 
     //---------------------------------------------------------------------------
     /// Sputnik DAO remote-upgrade receiver
@@ -258,7 +260,6 @@ impl Contract {
             });
         }
     }
-
 }
 
 #[near_bindgen]

--- a/p1-staking-pool-dyn/src/interfaces.rs
+++ b/p1-staking-pool-dyn/src/interfaces.rs
@@ -29,7 +29,7 @@ pub trait ExtSelf {
 #[ext_contract(ext_ft)]
 pub trait FungibleToken {
     fn ft_transfer(&mut self, receiver_id: AccountId, amount: U128, memo: Option<String>);
-    fn mint(&mut self, account_id: AccountId, amount: U128);
+    fn ft_mint(&mut self, account_id: AccountId, amount: U128);
 }
 
 #[derive(Deserialize, Serialize)]

--- a/p1-staking-pool-dyn/src/lib.rs
+++ b/p1-staking-pool-dyn/src/lib.rs
@@ -248,7 +248,7 @@ impl Contract {
     fn mint_cheddar_promise(&mut self, a: &AccountId, amount: U128) -> Promise {
         assert!(amount.0 > 0, "amount must be positive");
         // launch async callback to mint rewards for the user
-        ext_ft::mint(
+        ext_ft::ft_mint(
             a.clone().try_into().unwrap(),
             amount,
             &self.cheddar_id,


### PR DESCRIPTION
+ cheddar: renamed `mint`  to `ft_mint`
+ cheddar: rename `terminate_vesting` to `cancel_vesting`
+ cheddar: changed `ft_mint` permissions - only owner can call it
+ cheddar: removed `internal` prefix from `internal_unwrap_balance_of`